### PR TITLE
move node before import in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "node": "./node.mjs",
       "import": "./index.mjs",
       "main": "./index.mjs",
-      "browser": "./index.mjs",
-      "node": "./node.mjs"
+      "browser": "./index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This moves `"node"` before `"import"` as a conditional export. This makes a difference when importing from node files. Demo project available here: https://github.com/zoren/sqlite-wasm-demo