### PR TITLE
Add type def for versions object on type Sqlite3Static

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1887,6 +1887,14 @@ declare type Sqlite3Static = {
     DB: typeof Database;
   };
 
+  /** Version numbers */
+  version: {
+    libVersion: string,
+    libVersionNumber: number,
+    sourceId: string,
+    downloadVersion: number,
+  };
+
   /**
    * Initializes the Worker API.
    *


### PR DESCRIPTION
Thanks for all the hard work making this package.

Noticed `version` was missing on `Sqlite3Static` when trying out the examples and was getting errors on the following line.

```
log('Running SQLite3 version', sqlite3.version.libVersion);
```