### PR TITLE
xWrap return function should iterate over args array with a standard loop

### DIFF
--- a/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
+++ b/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
@@ -7799,8 +7799,9 @@ var sqlite3InitModule = (() => {
             if (args.length !== xf.length) __argcMismatch(fArg, xf.length);
             const scope = target.scopedAllocPush();
             try {
-              for (const i in args)
+              for (let i = 0; i < args.length; i++) {
                 args[i] = cxw.convertArgNoCheck(argTypes[i], args[i], args, i);
+              }
               return cxw.convertResultNoCheck(resultType, xf.apply(null, args));
             } finally {
               target.scopedAllocPop(scope);

--- a/sqlite-wasm/jswasm/sqlite3-node.mjs
+++ b/sqlite-wasm/jswasm/sqlite3-node.mjs
@@ -7844,8 +7844,9 @@ var sqlite3InitModule = (() => {
             if (args.length !== xf.length) __argcMismatch(fArg, xf.length);
             const scope = target.scopedAllocPush();
             try {
-              for (const i in args)
+              for (let i = 0; i < args.length; i++) {
                 args[i] = cxw.convertArgNoCheck(argTypes[i], args[i], args, i);
+              }
               return cxw.convertResultNoCheck(resultType, xf.apply(null, args));
             } finally {
               target.scopedAllocPop(scope);

--- a/sqlite-wasm/jswasm/sqlite3.js
+++ b/sqlite-wasm/jswasm/sqlite3.js
@@ -7827,8 +7827,9 @@ var sqlite3InitModule = (() => {
             if (args.length !== xf.length) __argcMismatch(fArg, xf.length);
             const scope = target.scopedAllocPush();
             try {
-              for (const i in args)
+              for (let i = 0; i < args.length; i++) {
                 args[i] = cxw.convertArgNoCheck(argTypes[i], args[i], args, i);
+              }
               return cxw.convertResultNoCheck(resultType, xf.apply(null, args));
             } finally {
               target.scopedAllocPop(scope);

--- a/sqlite-wasm/jswasm/sqlite3.mjs
+++ b/sqlite-wasm/jswasm/sqlite3.mjs
@@ -7803,8 +7803,9 @@ var sqlite3InitModule = (() => {
             if (args.length !== xf.length) __argcMismatch(fArg, xf.length);
             const scope = target.scopedAllocPush();
             try {
-              for (const i in args)
+              for (let i = 0; i < args.length; i++) {
                 args[i] = cxw.convertArgNoCheck(argTypes[i], args[i], args, i);
+              }
               return cxw.convertResultNoCheck(resultType, xf.apply(null, args));
             } finally {
               target.scopedAllocPop(scope);


### PR DESCRIPTION
Addresses https://github.com/sqlite/sqlite-wasm/issues/71

As described in that issue, in an environment where the global Array prototype has been extended ([such as Ember](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/), a `for...in` loop will [enumerate over these extended properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in). This means "for ... in" does not only iterate over the array elements, it will also iterate over array properties and functions.

This PR replaces the one instance of this pattern that was causing `sqlite3InitModule()` to fail in our environment.  There are other uses of `for...in` in this file, but in our application they have no negative effect.