### PR TITLE
Fix type `sqlite3session_attach`, that accepts `0` for `tableName` arg

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1415,6 +1415,8 @@ declare class SQLite3Error extends Error {
 /** A pointer to a location in WASM heap memory. */
 declare type WasmPointer = number;
 
+declare type NullPointer = 0 | null;
+
 declare type StructPtrMapper<T> = {
   StructType: T;
   /**
@@ -6548,7 +6550,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/session/sqlite3session_attach.html
    */
-  sqlite3session_attach: (pSession: WasmPointer, tableName: string | 0) => number;
+  sqlite3session_attach: (pSession: WasmPointer, tableName: string | NullPointer) => number;
 
   /**
    * Set a table filter on a Session Object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1415,7 +1415,7 @@ declare class SQLite3Error extends Error {
 /** A pointer to a location in WASM heap memory. */
 declare type WasmPointer = number;
 
-declare type NullPointer = 0 | null;
+declare type NullPointer = 0 | null | undefined;
 
 declare type StructPtrMapper<T> = {
   StructType: T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6548,7 +6548,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/session/sqlite3session_attach.html
    */
-  sqlite3session_attach: (pSession: WasmPointer, tableName: string) => number;
+  sqlite3session_attach: (pSession: WasmPointer, tableName: string || 0) => number;
 
   /**
    * Set a table filter on a Session Object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6548,7 +6548,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/session/sqlite3session_attach.html
    */
-  sqlite3session_attach: (pSession: WasmPointer, tableName: string || 0) => number;
+  sqlite3session_attach: (pSession: WasmPointer, tableName: string | 0) => number;
 
   /**
    * Set a table filter on a Session Object.


### PR DESCRIPTION
```
sqlite3.capi.sqlite3session_attach(pSession, 0);
```

is the easiest way to monitor all tables for changes. But this is not type-correct. This PR fixes that.