### PR TITLE
Add `undefined` and `boolean` to `BindingSpec` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,14 @@ declare type SqlValue =
   | Int8Array
   | ArrayBuffer;
 
+/** Types of values that can be passed to SQLite. */
+declare type BindableValue =
+  | SqlValue
+  /** converted to NULL */
+  | undefined
+  /** converted to INTEGER */
+  | boolean;
+
 /** Internal data types supported by SQLite3. */
 declare type SQLiteDataType =
   | CAPI['SQLITE_INTEGER']
@@ -18,12 +26,10 @@ declare type SQLiteDataType =
 
 /** Specifies parameter bindings. */
 declare type BindingSpec =
-  | readonly SqlValue[]
-  | { [paramName: string]: SqlValue }
+  | readonly BindableValue[]
+  | { [paramName: string]: BindableValue }
   /** Assumed to have binding index `1` */
-  | SqlValue
-  | undefined
-  | boolean;
+  | (SqlValue | boolean);
 
 /**
  * Certain WASM-bound APIs, where explicitly noted, have additional string-type

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,9 @@ declare type BindingSpec =
   | readonly SqlValue[]
   | { [paramName: string]: SqlValue }
   /** Assumed to have binding index `1` */
-  | SqlValue;
+  | SqlValue
+  | undefined
+  | boolean;
 
 /**
  * Certain WASM-bound APIs, where explicitly noted, have additional string-type


### PR DESCRIPTION
Even though these types will never be retrieved from SQLite, using them in a bind is perfectly valid.

`undefined` will get translated to `NULL`, `boolean` to `1` (true) or `0` (false).