### PR TITLE
Correct 'BigInt' types to 'bigint' (and add Typescript checking script)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare type SqlValue =
   | string
   | number
   | null
-  | BigInt
+  | bigint
   | Uint8Array
   | Int8Array
   | ArrayBuffer;
@@ -1862,9 +1862,9 @@ declare class sqlite3_index_info extends SQLiteStruct {
   needToFreeIdxStr: number;
   orderByConsumed: number;
   estimatedCost: number;
-  estimatedRows: BigInt;
+  estimatedRows: bigint;
   idxFlags: number;
-  colUsed: BigInt;
+  colUsed: bigint;
   sqlite3_index_constraint: sqlite3_index_constraint;
   sqlite3_index_orderby: sqlite3_index_orderby;
   sqlite3_index_constraint_usage: sqlite3_index_constraint_usage;
@@ -2705,7 +2705,7 @@ declare type WASM_API = {
    * Equivalent to peek(X,'i64'). Will throw if the environment is not
    * configured with BigInt support.
    */
-  peek64: (addr: WasmPointer) => BigInt;
+  peek64: (addr: WasmPointer) => bigint;
 
   /** Equivalent to peek(X,'f32') */
   peek32f: (addr: WasmPointer) => number;
@@ -3520,7 +3520,7 @@ declare type CAPI = {
     arg1: number,
     arg2: number,
   ): number;
-  sqlite3_config(op: CAPI['SQLITE_CONFIG_MEMDB_MAXSIZE'], arg: BigInt): number;
+  sqlite3_config(op: CAPI['SQLITE_CONFIG_MEMDB_MAXSIZE'], arg: bigint): number;
 
   /**
    * Used to make configuration changes to a database connection. The interface
@@ -3587,7 +3587,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/last_insert_rowid.html
    */
-  sqlite3_last_insert_rowid: (db: Database | WasmPointer) => BigInt;
+  sqlite3_last_insert_rowid: (db: Database | WasmPointer) => bigint;
 
   /**
    * Allows the application to set the value returned by calling
@@ -3602,7 +3602,7 @@ declare type CAPI = {
    */
   sqlite3_set_last_insert_rowid: (
     db: Database | WasmPointer,
-    rowid: BigInt,
+    rowid: bigint,
   ) => void;
 
   /**
@@ -3633,7 +3633,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/changes.html
    */
-  sqlite3_changes64: (db: Database | WasmPointer) => BigInt;
+  sqlite3_changes64: (db: Database | WasmPointer) => bigint;
 
   /**
    * Return the total number of rows inserted, modified or deleted by all
@@ -3665,7 +3665,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/total_changes.html
    */
-  sqlite3_total_changes64: (db: Database | WasmPointer) => BigInt;
+  sqlite3_total_changes64: (db: Database | WasmPointer) => bigint;
 
   /**
    * Useful during command-line input to determine if the currently entered text
@@ -3745,7 +3745,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/free.html
    */
-  sqlite3_malloc64: (numBytes: BigInt) => WasmPointer;
+  sqlite3_malloc64: (numBytes: bigint) => WasmPointer;
 
   /**
    * Attempts to resize a prior memory allocation X to be at least N bytes.
@@ -3785,7 +3785,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/free.html
    */
-  sqlite3_realloc64: (ptr: WasmPointer, numBytes: BigInt) => WasmPointer;
+  sqlite3_realloc64: (ptr: WasmPointer, numBytes: bigint) => WasmPointer;
 
   /**
    * Calling `sqlite3_free()` with a pointer previously returned by
@@ -3820,7 +3820,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/free.html
    */
-  sqlite3_msize: (ptr: WasmPointer) => BigInt;
+  sqlite3_msize: (ptr: WasmPointer) => bigint;
 
   /**
    * Pseudo-Random Number Generator
@@ -4006,8 +4006,8 @@ declare type CAPI = {
   sqlite3_uri_int64: (
     uri: string | WasmPointer,
     paramName: string | WasmPointer,
-    defaultVal: BigInt,
-  ) => BigInt;
+    defaultVal: bigint,
+  ) => bigint;
 
   /**
    * Returns a pointer to the name (not the value) of the `idx`-th query
@@ -4314,7 +4314,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/bind_blob.html
    */
-  sqlite3_bind_int64: (stmt: WasmPointer, idx: number, value: BigInt) => number;
+  sqlite3_bind_int64: (stmt: WasmPointer, idx: number, value: bigint) => number;
 
   /**
    * Bind a `NULL` value to a parameter in a prepared statement.
@@ -4568,7 +4568,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/column_blob.html
    */
-  sqlite3_column_int64: (db: Database | WasmPointer, colIdx: number) => BigInt;
+  sqlite3_column_int64: (db: Database | WasmPointer, colIdx: number) => bigint;
 
   /**
    * Get a TEXT result value from a column in the current result row.
@@ -4804,7 +4804,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/value_blob.html
    */
-  sqlite3_value_int64: (sqliteValue: WasmPointer) => BigInt;
+  sqlite3_value_int64: (sqliteValue: WasmPointer) => bigint;
 
   /**
    * Extract a pointer value from a protected `sqlite3_value` object. If the
@@ -5162,7 +5162,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/result_blob.html
    */
-  sqlite3_result_int64: (ctx: WasmPointer, value: BigInt) => void;
+  sqlite3_result_int64: (ctx: WasmPointer, value: bigint) => void;
 
   /**
    * Sets the return value of the application-defined function to be `NULL`.
@@ -5244,7 +5244,7 @@ declare type CAPI = {
    *
    * See https://www.sqlite.org/c3ref/result_blob.html
    */
-  sqlite3_result_zeroblob64: (ctx: WasmPointer, blobLen: BigInt) => void;
+  sqlite3_result_zeroblob64: (ctx: WasmPointer, blobLen: bigint) => void;
 
   /**
    * Causes the subtype of the result from the application-defined SQL function
@@ -5289,7 +5289,7 @@ declare type CAPI = {
       | null
       | boolean
       | number
-      | BigInt
+      | bigint
       | string
       | Uint8Array
       | Int8Array
@@ -5505,7 +5505,7 @@ declare type CAPI = {
       op: CAPI['SQLITE_UPDATE'] | CAPI['SQLITE_DELETE'] | CAPI['SQLITE_INSERT'],
       dbName: string,
       tableName: string,
-      newRowId: BigInt,
+      newRowId: bigint,
     ) => void,
     userCtx: WasmPointer,
   ) => WasmPointer;
@@ -6257,8 +6257,8 @@ declare type CAPI = {
       op: CAPI['SQLITE_UPDATE'] | CAPI['SQLITE_DELETE'] | CAPI['SQLITE_INSERT'],
       dbName: string,
       tableName: string,
-      oldRowid: BigInt,
-      newRowid: BigInt,
+      oldRowid: bigint,
+      newRowid: bigint,
     ) => void,
   ) => void;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "prettier": "^3.3.3",
         "prettier-plugin-jsdoc": "^1.3.0",
         "publint": "^0.2.10",
-        "shx": "^0.3.4"
+        "shx": "^0.3.4",
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@types/debug": {
@@ -1897,6 +1898,19 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
   },
   "scripts": {
     "publint": "npx publint",
+    "check-types": "tsc",
     "clean": "shx rm -rf sqlite-wasm",
     "build": "npm run clean && node bin/index.js",
     "start": "npx http-server --coop",
     "fix": "npx prettier . --write",
-    "prepublishOnly": "npm run build && npm run fix && npm run publint",
+    "prepublishOnly": "npm run build && npm run fix && npm run publint && npm run check-types",
     "deploy": "npm run prepare && git add . && git commit -am 'New release' && git push && npm publish --access public"
   },
   "repository": {
@@ -58,8 +59,9 @@
     "module-workers-polyfill": "^0.3.2",
     "node-fetch": "^3.3.2",
     "prettier": "^3.3.3",
-    "publint": "^0.2.10",
     "prettier-plugin-jsdoc": "^1.3.0",
-    "shx": "^0.3.4"
+    "publint": "^0.2.10",
+    "shx": "^0.3.4",
+    "typescript": "^5.5.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "noEmit": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
First off, fantastic work on this project! The recent addition of Typescript types is a massive feature, especially for such a complex and unorthodox (in JS) API.

I noticed one small glitch in them when introducing the latest version to my private project, where I had already begun using an older, less comprehensive type declaration and my own `bigint` types. The glitch is that `BigInt` types are used, but they should be `bigint` instead. It's a very confusing situation, but the PascalCased 'object types' for primitive values are actually just the type of the _constructor function_ for the boxed object versions of the primitives. It's usually a mistake to use those as the type of the values themselves, and it can cause issues in usage, the main one being that `BigInt` and `bigint` are not assignable to each other (which makes sense, one is a number and one is a constructor function):
<img width="643" alt="image" src="https://github.com/user-attachments/assets/267a6db6-c437-4d1c-ab05-b8da250d39aa">

Some sources that explain this in some more detail:
- https://stackoverflow.com/questions/76477290/what-is-the-difference-between-bigint-lowercase-and-bigint
- https://typescript-eslint.io/rules/no-wrapper-object-types/

This changeset fixes those types, and it also adds Typescript as a dev dependency, as well as a barebones tsconfig.json and a package.json script to run it and type-check index.d.ts. It wasn't failing before this change, but it's nice to have to make sure type changes don't introduce an internal error.