### PR TITLE
Add sqlite3.wasm as explicit package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "main": "./index.mjs",
       "browser": "./index.mjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./sqlite3.wasm": "./sqlite-wasm/jswasm/sqlite3.wasm"
   },
   "bin": {
     "sqlite-wasm": "bin/index.js"


### PR DESCRIPTION
This PR adds a new field to `exports` in the `package.json` called `"./sqlite3.wasm"` that acts as a pointer to the WebAssembly binary shipped with the module. This allows tools, such as [Vite](https://vite.dev), that are strict about deep package file access to nonetheless serve the `.wasm` file in an ergonomic way.

I suspect that the explicit export of the WebAssembly binary will find general usefulness beyond the Vite.

For example, with the suggested change, this is now possible:

```js
// @ts-check

///<reference lib="dom" />
///<reference types="vite/client" />

import initSqliteWasm from "@sqlite.org/sqlite-wasm";
import sqliteWasmUrl from "@sqlite.org/sqlite-wasm/sqlite3.wasm?url";

async function main() {
  const sqlite3 = await initSqliteWasm({
    locateFile(path, prefix) {
      return sqliteWasmUrl;
    },
    print(msg) {
      console.debug("[sqlite stdout]: %s", msg);
    },
    printErr(msg) {
      console.debug("[sqlite stderr]: %s", msg);
    },
  });

  console.log(sqlite3);
}

main().catch((e) => {
  console.error(e);
});
```