### PR TITLE
Update types for importDb

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1260,7 +1260,11 @@ declare class OpfsDatabase extends Database {
    */
   static importDb(
     filename: string,
-    data: Uint8Array | ArrayBuffer,
+    data:
+      | Uint8Array 
+      | ArrayBuffer 
+      | (() => Uint8Array | ArrayBuffer | undefined) 
+      | (() => Promise<Uint8Array | ArrayBuffer | undefined>),
   ): Promise<number>;
 }
 
@@ -1350,8 +1354,9 @@ type SAHPoolUtil = {
   importDb: (
     name: string,
     data:
-      | Uint8Array
-      | ArrayBuffer
+      | Uint8Array 
+      | ArrayBuffer 
+      | (() => Uint8Array | ArrayBuffer | undefined) 
       | (() => Promise<Uint8Array | ArrayBuffer | undefined>),
   ) => Promise<number>;
 


### PR DESCRIPTION
Updated the types for the `importDb` methods to fully account for the accepted forms that the data argument can be passed in: a callback that may or may not be async which returns `Uint8Array | ArrayBuffer | undefined` as documented [here](https://sqlite.org/wasm/doc/trunk/api-oo1.md#opfsdb).