### PR TITLE
fix: replace self with globalThis

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,7 @@
 import { default as sqlite3InitModule } from './sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs';
 import './sqlite-wasm/jswasm/sqlite3-worker1-promiser.mjs';
 
-const sqlite3Worker1Promiser = self.sqlite3Worker1Promiser;
+const sqlite3Worker1Promiser = globalThis.sqlite3Worker1Promiser;
 
 export default sqlite3InitModule;
 export { sqlite3Worker1Promiser };


### PR DESCRIPTION
Upstream package is setting `globalThis.sqlite3Worker1Promiser`, hence `self.sqlite3Worker1Promiser` will fail at runtime.