### PR TITLE
fix node export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "node": "./index.mjs",
       "types": "./index.d.ts",
       "import": "./index.mjs",
       "main": "./index.mjs",


### PR DESCRIPTION
Fixes this error message below. 

Why the error occurs is unknown and might be specific to nextjs. But, adding `node` to the export path fixes the issue.

```
 ⨯ Failed to load next.config.ts, see more info here https://nextjs.org/docs/messages/next-config-error

> Build error occurred
[Error: No "exports" main defined in /Users/samuel/git-repos/monorepo/packages/sqlite-wasm-kysely/node_modules/@sqlite.org/sqlite-wasm/package.json] {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```