### PR TITLE
Update JsStorageDb constructor type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1163,6 +1163,7 @@ declare class Database {
  */
 declare class JsStorageDb extends Database {
   /** Create a new kvvfs-backed database in local or session storage. */
+  constructor(options?: { filename?: 'local' | 'session'; flags?: string; });
   constructor(mode: 'local' | 'session');
 
   /** Returns an _estimate_ of how many bytes of storage are used by the kvvfs. */


### PR DESCRIPTION
Updated the types to add an overload for `JsStorageDb` that accepts an object as documented [here](https://sqlite.org/wasm/doc/trunk/api-oo1.md#jsstoragedb): "As of version 3.46, the constructor optionally accepts an options object in the same form as the DB class's constructor, instead of just a file name. That enables, e.g., activation of SQL tracing on these objects."