### PR TITLE
Expose releaseAccessHandles and acquireAccessHandles

### DIFF
--- a/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
+++ b/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs
@@ -13769,6 +13769,14 @@ var sqlite3InitModule = (() => {
           async removeVfs() {
             return this.#p.removeVfs();
           }
+
+          releaseAccessHandles() {
+            return this.#p.releaseAccessHandles();
+          }
+
+          async acquireAccessHandles() {
+            return this.#p.acquireAccessHandles(false);
+          }
         }
 
         const apiVersionCheck = async () => {


### PR DESCRIPTION
For [logseq](https://github.com/logseq/logseq/tree/feat/db) we need to release all the accessed file handles for the current graph before switching to another graph.