### PR TITLE
fix(sqlite3_js_db_export): more specific return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7582,7 +7582,7 @@ declare type CAPI = {
   sqlite3_js_db_export: (
     db: Database | WasmPointer,
     schema?: string | WasmPointer,
-  ) => Uint8Array;
+  ) => Uint8Array<ArrayBuffer>;
 
   /**
    * Given a `sqlite3*` and a database name (JS string or WASM C-string pointer,


### PR DESCRIPTION
If no type-argument is specified, then `Uint8Array` defaults to `Uint8Array<ArrayBufferLike>`.

Making the type defintion more specific is generally helpful, but also fixes an issue: In nodejs, [`Blob` accepts  `ArrayBuffer | BinaryLike`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/798a9dcd2acc5da3452dde66bfe261209b1e5590/types/node/buffer.d.ts#L166), which is not the same `ArrayBufferLike`.
