### PR TITLE
fix: add types to SAHPoolUtil for VFS pause functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1412,6 +1412,17 @@ type SAHPoolUtil = {
    * currently in use, e.g. by an sqlite3 db.
    */
   wipeFiles: () => Promise<void>;
+
+  /** Unregister this VFS and release file access handles, without clearing
+   * files. The database must be closed before calling this. */
+  pauseVfs: () => SAHPoolUtil;
+
+  /** Returns `true` if this VFS pool is paused */
+  isPaused: () => boolean;
+
+  /** Re-register this VFS and re-acquire file access handles. Any previously
+   * open databases will have to be re-opened after calling this. */
+  unpauseVfs: () => Promise<SAHPoolUtil>;
 };
 
 /** Exception class for reporting WASM-side allocation errors. */


### PR DESCRIPTION
The `SAHPoolUtil` type is missing the functions introduced in sqlite-wasm 3.50 that can pause and unpause the VFS (allowing you to release the file access handles without closing the tab and/or without wiping the database).

I've added what's missing here, altough the doc comments are just a best guess.