### PR TITLE
Allow NullPointer to be passed to sqlite3_set_authorizer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3915,7 +3915,7 @@ declare type CAPI = {
       arg2: string | 0,
       arg3: string | 0,
       arg4: string | 0,
-    ) => number,
+    ) => number | NullPointer,
     cbArg: WasmPointer,
   ) => number;
 


### PR DESCRIPTION
> Only a single authorizer can be in place on a database connection at a time. Each call to sqlite3_set_authorizer overrides the previous call. Disable the authorizer by installing a NULL callback. The authorizer is disabled by default.

https://www.sqlite.org/c3ref/set_authorizer.html
